### PR TITLE
feat: add site config model fields

### DIFF
--- a/src/configFields.ts
+++ b/src/configFields.ts
@@ -1,0 +1,88 @@
+export const contactInformation = {
+  name: 'contactInformation',
+  label: 'Contact Information',
+  hint: 'The contact information for this organization',
+  widget: 'object',
+  fields: [
+    {
+      name: 'address',
+      label: 'Address',
+      hint:
+        '(Optional) The address as you would like it displayed in the Contact section of the site',
+      required: false,
+      widget: 'text',
+    },
+    {
+      name: 'phone',
+      label: 'Phone Number',
+      hint:
+        '(Optional) The phone number as you would like it to be displayed in the Contact section of the site',
+      required: false,
+    },
+    {
+      name: 'email',
+      label: 'Email Address',
+      hint:
+        '(Optional) The email address as you would displayed in the Contact section of the site',
+      required: false,
+    },
+  ],
+}
+
+export const donorboxName = {
+  name: 'donorboxName',
+  label: 'Donorbox Name',
+  hint: '(Optional) The Donorbox name for this organization',
+  required: false,
+}
+
+export const featureImage = {
+  name: 'featureImage',
+  label: 'Feature Image',
+  hint: "(Optional) The feature image for this organization's home page",
+  required: false,
+  widget: 'image',
+}
+
+export const contactFormUrl = {
+  name: 'contactFormUrl',
+  label: 'Contact Form URL',
+  hint:
+    '(Optional) The contact form URL to where submitted contact forms will send data',
+  required: false,
+}
+
+export const teamMembers = {
+  name: 'team',
+  label: 'Team Members',
+  hint: '(Optional) The team members for this organization',
+  required: false,
+  widget: 'list',
+  fields: [
+    { name: 'name', label: 'Name' },
+    { name: 'photo', widget: 'image', required: false },
+    { name: 'bio', label: 'Bio', required: false },
+  ],
+}
+
+export const timeline = {
+  name: 'timeline',
+  hint:
+    '(Optional) The timeline entries that help tell the story of this organization',
+  required: false,
+  widget: 'list',
+  fields: [
+    {
+      name: 'date',
+      hint:
+        'The date as you would like it to be displayed on the website (e.g. 2012-2013)',
+    },
+    {
+      name: 'photo',
+      widget: 'image',
+      hint: '(Optional) The photo associated with this timeline entry',
+      required: false,
+    },
+    { name: 'body', hint: 'The text associated with this timeline entry' },
+  ],
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,99 +1,40 @@
-interface Window {
-  CMS: object
-  initCMS(object: any): void
-}
-
-interface Field {
-  name: string
-  label?: string
-  widget?: string
-  hint?: string
-  default?: any
-  required?: boolean
-  pattern?: [string, string]
-}
-
-const sites = ['youwillbecome.org', 'cultivate.org', 'kingdomsea.org'].sort()
-
-function Blog(site) {
-  return {
-    name: `blog.${site}`,
-    label: `Blog (${site})`,
-    description: `Blog posts for ${site}`,
-    folder: `sites/${site}/blog`,
-    create: true,
-    fields: [
-      { name: 'title', label: 'Title' },
-      { name: 'date', label: 'Date', widget: 'date' },
-      { name: 'body', label: 'Body', widget: 'markdown' },
-    ],
-  }
-}
-
-function Pages(site) {
-  return {
-    label: `Pages (${site})`,
-    name: `pages.${site}`,
-    files: [
-      {
-        label: 'About Page',
-        name: 'about',
-        file: `sites/${site}/pages/about.yml`,
-        fields: [{ name: 'title', label: 'Title' }],
-      },
-    ],
-  }
-}
-
-function Info(sites) {
-  const infoFields: Field[] = [
-    {
-      name: 'address',
-      label: 'Address',
-      hint:
-        '(Optional) The address as you would like it displayed in the Contact section of the site',
-      required: false,
-    },
-    {
-      name: 'phone',
-      label: 'Phone Number',
-      hint:
-        '(Optional) The phone number as you would like it to be displayed in the Contact section of the site',
-      required: false,
-    },
-    {
-      name: 'email',
-      label: 'Email Address',
-      hint:
-        '(Optional) The email address as you would displayed in the Contact section of the site',
-      required: false,
-    },
-  ]
-  return {
-    label: `Info`,
-    name: `info`,
-    editor: { preview: false },
-    files: sites.map(site => ({
-      label: site,
-      name: site,
-      file: `sites/${site}/info.yml`,
-      fields: infoFields,
-    })),
-  }
-}
-
-const backend =
-  process.env.NODE_ENV === 'production'
-    ? { name: 'github', repo: 'abide-community/content' }
-    : { name: 'test-repo' }
+import {
+  contactFormUrl,
+  contactInformation,
+  donorboxName,
+  featureImage,
+  teamMembers,
+  timeline,
+} from './configFields'
+import sites from './sites'
 
 window.initCMS({
   config: {
-    backend,
+    backend:
+      process.env.NODE_ENV === 'production'
+        ? { name: 'github', repo: 'abide-community/content' }
+        : { name: 'test-repo' },
     publish_mode: 'simple',
     media_folder: 'static/assets',
-    collections: sites
-      .reduce((arr, site) => [...arr, Blog(site), Pages(site)], [])
-      .concat(Info(sites)),
+    collections: [
+      {
+        label: 'Config',
+        name: 'config',
+        editor: { preview: false },
+        files: sites.map(site => ({
+          label: site,
+          name: site,
+          file: `sites/${site}/config.yml`,
+          fields: [
+            contactInformation,
+            donorboxName,
+            featureImage,
+            contactFormUrl,
+            teamMembers,
+            timeline,
+          ],
+        })),
+      },
+    ],
   },
 })

--- a/src/sites.ts
+++ b/src/sites.ts
@@ -1,0 +1,3 @@
+const sites = ['youwillbecome.org', 'cultivate.org', 'kingdomsea.org'].sort()
+
+export default sites


### PR DESCRIPTION
This gets most of the initial CMS fields in place. I'm going to use this PR to test out some Netlify configuration as well so we can preview PRs.